### PR TITLE
adding call graph rewrite pass

### DIFF
--- a/src/bloqade/shuttle/passes/callgraph.py
+++ b/src/bloqade/shuttle/passes/callgraph.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+
+from kirin import ir, passes
+from kirin.dialects import func
+from kirin.passes import Pass
+from kirin.rewrite import Walk
+from kirin.rewrite.abc import RewriteResult, RewriteRule
+
+
+@dataclass
+class ReplaceMethods(RewriteRule):
+    new_symbols: dict[ir.Method, ir.Method]
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        if (
+            not isinstance(node, func.Invoke)
+            or (new_callee := self.new_symbols.get(node.callee)) is None
+        ):
+            return RewriteResult()
+
+        node.replace_by(
+            func.Invoke(
+                callee=new_callee,
+                inputs=node.inputs,
+                kwargs=node.kwargs,
+            )
+        )
+
+        return RewriteResult(has_done_something=True)
+
+
+@dataclass
+class CallGraphPass(Pass):
+    """Copy all functions in the call graph and apply a rule to each of them."""
+
+    rule: RewriteRule
+    """The rule to apply to each function in the call graph."""
+
+    def methods_on_callgraph(self, mt: ir.Method) -> set[ir.Method]:
+
+        callees = set([mt])
+        for stmt in mt.callable_region.walk():
+            if isinstance(stmt, func.Invoke):
+                print(f"Found callee: {stmt.callee.sym_name}")
+                if stmt.callee not in callees:
+                    callees.update(self.methods_on_callgraph(stmt.callee))
+
+        return callees
+
+    def unsafe_run(self, mt: ir.Method) -> RewriteResult:
+        result = RewriteResult()
+        mt_map = {}
+
+        subroutines = self.methods_on_callgraph(mt)
+        for original_mt in subroutines:
+            if original_mt is mt:
+                new_mt = original_mt
+            else:
+                new_mt = original_mt.similar()
+            result = self.rule.rewrite(new_mt.code).join(result)
+            mt_map[original_mt] = new_mt
+
+        if result.has_done_something:
+            for _, new_mt in mt_map.items():
+                Walk(ReplaceMethods(mt_map)).rewrite(new_mt.code)
+                passes.Fold(self.dialects)(new_mt)
+
+        return result

--- a/src/bloqade/shuttle/passes/inject_spec.py
+++ b/src/bloqade/shuttle/passes/inject_spec.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 
 from kirin import ir, rewrite
-from kirin.dialects import func
 from kirin.dialects.py import Constant
 from kirin.ir.nodes.stmt import Statement
 from kirin.passes import Fold, HintConst, Pass
@@ -9,6 +8,7 @@ from kirin.rewrite.abc import RewriteResult, RewriteRule
 
 from bloqade.shuttle.arch import ArchSpec
 from bloqade.shuttle.dialects import path, spec
+from bloqade.shuttle.passes.callgraph import CallGraphPass
 
 
 @dataclass
@@ -20,22 +20,6 @@ class InjectSpecRule(RewriteRule):
         if isinstance(node, path.Gen) and node.arch_spec is None:
             node.arch_spec = self.arch_spec
             return RewriteResult(has_done_something=True)
-        elif isinstance(node, func.Invoke):
-            # make sure to mark this method as visited to handle recursive calls
-            new_callee = self.visited.get(callee := node.callee)
-            if new_callee is None:
-                self.visited[callee] = (new_callee := callee.similar())
-                rewrite.Walk(self).rewrite(new_callee.code)
-
-            node.replace_by(
-                func.Invoke(
-                    node.inputs,
-                    callee=new_callee,
-                    kwargs=node.kwargs,
-                    purity=node.purity,
-                )
-            )
-            return RewriteResult(has_done_something=True)
         elif (
             isinstance(node, spec.GetStaticTrap)
             and (zone_id := node.zone_id) in self.arch_spec.layout.static_traps
@@ -43,8 +27,8 @@ class InjectSpecRule(RewriteRule):
             node.replace_by(Constant(self.arch_spec.layout.static_traps[zone_id]))
 
             return RewriteResult(has_done_something=True)
-
-        return RewriteResult()
+        else:
+            return RewriteResult()
 
 
 @dataclass
@@ -55,7 +39,8 @@ class InjectSpecsPass(Pass):
     def unsafe_run(self, mt: ir.Method) -> RewriteResult:
         # since we're rewriting `mt` inplace we should make sure it is on the visited list
         # so that recursive calls are handed correctly
-        result = rewrite.Walk(InjectSpecRule(self.arch_spec, {mt: mt})).rewrite(mt.code)
+        rule = rewrite.Walk(InjectSpecRule(self.arch_spec, {mt: mt}))
+        result = CallGraphPass(mt.dialects, rule)(mt)
         if self.fold:
             result = HintConst(mt.dialects)(mt).join(result)
             result = Fold(mt.dialects)(mt).join(result)


### PR DESCRIPTION
This PR adds a new pass that applies a rewrite rule across all functions in a call graph, making sure to copy the subroutines first to avoid mutating them in place. After that, it goes through all these subroutines and makes sure they invoke the new methods. 