### PR TITLE
Do not catch inside method, this breaks the stack trace

### DIFF
--- a/src/bloqade/shuttle/dialects/path/constprop.py
+++ b/src/bloqade/shuttle/dialects/path/constprop.py
@@ -1,7 +1,7 @@
 from typing import cast
 
 from kirin.analysis import const, forward
-from kirin.interp import InterpreterError, MethodTable, impl
+from kirin.interp import MethodTable, impl
 
 from bloqade.shuttle.codegen import TraceInterpreter, reverse_path
 from bloqade.shuttle.dialects import schedule
@@ -43,17 +43,14 @@ class ConstProp(MethodTable):
             device_task.move_fn.arg_names, inputs_results, kwargs
         )
 
-        try:
-            path = TraceInterpreter(stmt.arch_spec).run_trace(
-                device_task.move_fn,
-                tuple(
-                    cast(const.Value, arg).data if isinstance(arg, const.Value) else arg
-                    for arg in args
-                ),
-                {},
-            )
-        except InterpreterError:
-            return (const.Result.top(),)
+        path = TraceInterpreter(stmt.arch_spec).run_trace(
+            device_task.move_fn,
+            tuple(
+                cast(const.Value, arg).data if isinstance(arg, const.Value) else arg
+                for arg in args
+            ),
+            {},
+        )
 
         if reverse:
             path = reverse_path(path)


### PR DESCRIPTION
Having the try-except block inside constant prop makes it so that you can't catch any errors when you set `no_raise=False`. 