### PR TITLE
Add CSE and DCE to `AddressiveUnroll` pass. 

### DIFF
--- a/src/bloqade/shuttle/passes/fold.py
+++ b/src/bloqade/shuttle/passes/fold.py
@@ -38,8 +38,6 @@ class Fold(Pass):
             InlineGetItem(),
             ilist.rewrite.InlineGetItem(),
             ilist.rewrite.HintLen(),
-            DeadCodeElimination(),
-            CommonSubexpressionElimination(),
         )
         result = Fixpoint(Walk(rule)).rewrite(mt.code).join(result)
 
@@ -71,6 +69,13 @@ class AggressiveUnroll(Pass):
         result = self.fold.unsafe_run(mt).join(result)
         result = Walk(Inline(self.inline_heuristic)).rewrite(mt.code).join(result)
         result = Walk(Fixpoint(CFGCompactify())).rewrite(mt.code).join(result)
+
+        rule = Chain(
+            CommonSubexpressionElimination(),
+            DeadCodeElimination(),
+        )
+        result = Fixpoint(Walk(rule)).rewrite(mt.code).join(result)
+
         return result
 
     @classmethod


### PR DESCRIPTION
The current implementation does not properly eliminate all rundendent paths executed in the kernel. Adding these extra rewrite rules makes sure that any redundant paths are eliminated in the final Kernel. 