### PR TITLE
Bump bloqade-circuit to 0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "bloqade-geometry ~=0.3.3",
-    "bloqade-circuit >=0.6.0,<0.8.0-dev",
+    "bloqade-circuit >=0.6.0,<0.16.0-dev",
     "kirin-toolchain >= 0.17.23,<0.18.0-dev",
 ]
 


### PR DESCRIPTION
Follows the `bloqade-circuit` 0.15.0 release (now live on PyPI). Updates the
`bloqade-circuit` version constraint. CI will surface any breakage.

Note: `uv.lock` was intentionally **not** regenerated in this PR. Re-locking here
either fails or produces large unrelated churn because it needs the internal
package index and prerelease settings that are only available in CI / a
maintainer's environment. Please refresh the lockfile before merging.

Opened as part of the coordinated bloqade-circuit 0.15.0 ecosystem release.
